### PR TITLE
Add absori

### DIFF
--- a/whimstan/stan_code/host_hbm.stan
+++ b/whimstan/stan_code/host_hbm.stan
@@ -1,4 +1,5 @@
 functions {
+#include absori.stan 
 #include tbabs.stan
 #include powerlaw.stan
 #include cstat.stan


### PR DESCRIPTION
small bug fix. The host_hbm.stan  does not run at the moment without it.